### PR TITLE
Refactor: Use Graph instead of the API

### DIFF
--- a/src/modules/governance/api.ts
+++ b/src/modules/governance/api.ts
@@ -4,11 +4,10 @@ import {getHumanValue} from 'web3/utils';
 
 import config from 'config';
 import {ApolloClient, gql, InMemoryCache} from "@apollo/client";
-import {getProposalStateCall, ProposalState} from "./contracts/daoGovernance";
+import {VotingPower} from "./votingPower";
+import {ProposalHistory} from "./stateHistory";
 
 const API_URL = config.api.baseUrl;
-const BASE_MULTIPLIER = new BigNumber(10).pow(18);
-const ONE_YEAR = new BigNumber(31556926);
 
 type PaginatedResult<T extends Record<string, any>> = {
   data: T[];
@@ -71,30 +70,6 @@ export type APIVoterEntity = {
   hasActiveDelegation: boolean;
 };
 
-function computeMultiplier(lockedUntil: number, now: number) {
-  if (now >= lockedUntil) {
-    return BASE_MULTIPLIER;
-  }
-
-  let diff = new BigNumber(lockedUntil - now);
-  if (diff.gte(ONE_YEAR)) {
-    return BASE_MULTIPLIER.multipliedBy(new BigNumber(2));
-  }
-  return BASE_MULTIPLIER.plus(diff.multipliedBy(BASE_MULTIPLIER).dividedBy(ONE_YEAR));
-}
-
-function calculateVotingPower(voter: APIVoterEntity): BigNumber {
-  let now = Math.floor(Date.now() / 1000);
-  let ownVotingPower: BigNumber;
-  if (voter.hasActiveDelegation) {
-    ownVotingPower = BigNumber.ZERO;
-  } else {
-    const multiplier = computeMultiplier(voter.lockedUntil, now);
-    ownVotingPower = (new BigNumber(voter.tokensStaked)).multipliedBy(multiplier).dividedBy(BASE_MULTIPLIER);
-  }
-  return ownVotingPower.plus(voter.delegatedPower);
-}
-
 export function fetchVoters(page = 1, limit = 10): Promise<PaginatedResult<APIVoterEntity>> {
   const client = new ApolloClient({
     uri: config.graph.graphUrl,
@@ -131,14 +106,14 @@ export function fetchVoters(page = 1, limit = 10): Promise<PaginatedResult<APIVo
 
       return {
         ...result,
-        data: (result.data.voters ?? []).map((item: any) => ({
-          address: item.id,
-          tokensStaked: getHumanValue(new BigNumber(item.tokensStaked), 18),
-          lockedUntil: item.lockedUntil,
-          delegatedPower: getHumanValue(new BigNumber(item.delegatedPower), 18),
-          votes: item.votes,
-          proposals: item.proposals,
-          votingPower: getHumanValue(calculateVotingPower(item), 18)
+        data: (result.data.voters ?? []).map((voter: any) => ({
+          address: voter.id,
+          tokensStaked: getHumanValue(new BigNumber(voter.tokensStaked), 18),
+          lockedUntil: voter.lockedUntil,
+          delegatedPower: getHumanValue(new BigNumber(voter.delegatedPower), 18),
+          votes: voter.votes,
+          proposals: voter.proposals,
+          votingPower: getHumanValue(VotingPower.calculate(voter), 18)
         })),
         meta: {count: result.data.overview.kernelUsers, block: 0}
       };
@@ -201,22 +176,6 @@ export type APILiteProposalEntity = {
   forVotes: BigNumber;
   againstVotes: BigNumber;
 };
-
-function getTimeLeft(state: string, proposal: any): number {
-  const now = Math.floor(Date.now() / 1000);
-  switch (state) {
-    case APIProposalState.WARMUP:
-      return proposal.createTime + proposal.warmUpDuration - now;
-    case APIProposalState.ACTIVE:
-      return proposal.createTime + proposal.warmUpDuration + proposal.activeDuration - now;
-    case APIProposalState.QUEUED:
-      return proposal.createTime + proposal.warmUpDuration + proposal.activeDuration + proposal.queueDuration - now;
-    case APIProposalState.GRACE:
-      return proposal.createTime + proposal.warmUpDuration + proposal.queueDuration + proposal.gracePeriodDuration - now;
-    default:
-      return 0;
-  }
-}
 
 function buildStateFilter(state: string) {
   if (state == "ALL") {
@@ -290,11 +249,11 @@ export function fetchProposals(
       for (let i = 0; i < response.data.proposals.length; i++) {
         const graphProposal = response.data.proposals[i];
         const liteProposal: APILiteProposalEntity = {...graphProposal};
-        const history = await buildProposalHistory(graphProposal);
+        const history = await ProposalHistory.build(graphProposal);
         liteProposal.proposalId = Number.parseInt(graphProposal.id);
         liteProposal.forVotes = getHumanValue(new BigNumber(graphProposal.forVotes), 18)!;
         liteProposal.againstVotes = getHumanValue(new BigNumber(graphProposal.againstVotes), 18)!
-        liteProposal.stateTimeLeft = getTimeLeft(state, graphProposal);
+        liteProposal.stateTimeLeft = ProposalHistory.computeTimeLeft(state, graphProposal);
         liteProposal.state = history[0].name as APIProposalState;
         result.data.push(liteProposal);
       }
@@ -336,185 +295,6 @@ export type APIProposalEntity = APILiteProposalEntity & {
   calldatas: string[];
   history: APIProposalHistoryEntity[];
 };
-
-function checkForCancelledEvent(eventsCopy: Array<any>, nextDeadline: number, history: APIProposalHistoryEntity[]) {
-  if (eventsCopy.length > 0 && eventsCopy[0].createTime < nextDeadline && eventsCopy[0].eventType == "CANCELED") {
-    history.push({
-      name: APIProposalState.CANCELED,
-      startTimestamp: eventsCopy[0].createTime,
-      endTimestamp: 0,
-      txHash: eventsCopy[0].txHash
-    })
-  }
-}
-
-function shouldStopBuilding(nextDeadline: number) {
-  return nextDeadline >= Math.floor(Date.now() / 1000);
-}
-
-async function calculateEvents(proposal: any) {
-  let history = new Array<APIProposalHistoryEntity>();
-  let eventsCopy = JSON.parse(JSON.stringify(proposal.events)) as Array<any>;
-  eventsCopy.sort((a: any, b: any) => {
-    return a.createTime - b.createTime;
-  });
-
-  history.push({
-    name: APIProposalState.CREATED,
-    startTimestamp: proposal.createTime,
-    endTimestamp: 0,
-    txHash: eventsCopy[0].txHash
-  });
-  // Remove Created event
-  eventsCopy = eventsCopy.slice(1);
-  history.push({
-    name: APIProposalState.WARMUP,
-    startTimestamp: proposal.createTime,
-    endTimestamp: 0, //proposal.createTime+ proposal.warmUpDuration,
-    txHash: ""
-  });
-
-  let nextDeadline = proposal.createTime + proposal.warmUpDuration;
-  // at this point, only a CANCELED event can occur that would be final for this history
-  // so we check the list of events to see if there's any CANCELED event that occurred before the WARMUP period ended
-  checkForCancelledEvent(eventsCopy, nextDeadline, history);
-
-  if (shouldStopBuilding(nextDeadline)) {
-    return history;
-  }
-
-  // if the proposal was not canceled in the WARMUP period, then it means we reached ACTIVE state so we add that to
-  // the history
-  history.push({
-    name: APIProposalState.ACTIVE,
-    startTimestamp: nextDeadline + 1,
-    endTimestamp: 0,
-    txHash: ""
-  });
-
-  // just like in WARMUP period, the only final event that could occur in this case is CANCELED
-  nextDeadline = proposal.createTime + proposal.warmUpDuration + proposal.activeDuration;
-  checkForCancelledEvent(eventsCopy, nextDeadline, history);
-
-  if (shouldStopBuilding(nextDeadline)) {
-    return history;
-  }
-
-  const proposalState = await getProposalStateCall(proposal.id)
-  history.push({
-    name: proposalState === ProposalState.Failed ? APIProposalState.FAILED : APIProposalState.ACCEPTED,
-    startTimestamp: nextDeadline + 1,
-    endTimestamp: 0,
-    txHash: ""
-  });
-
-  // after the proposal reached accepted state, nothing else can happen unless somebody calls the queue function
-  // which emits a QUEUED event
-  if(eventsCopy.length == 0) {
-    return history;
-  }
-
-  if (eventsCopy[0].eventType == APIProposalState.QUEUED) {
-    history.push({
-      name: APIProposalState.QUEUED,
-      startTimestamp: proposal.createTime + proposal.warmUpDuration + proposal.activeDuration + 1,
-      endTimestamp: 0,
-      txHash: eventsCopy[0].txHash,
-    })
-  }
-  eventsCopy = eventsCopy.slice(1);
-
-  nextDeadline = proposal.createTime + proposal.warmUpDuration + proposal.activeDuration + proposal.queueDuration;
-  if (shouldStopBuilding(nextDeadline)) {
-    return history;
-  }
-
-  if (proposalState == ProposalState.Abrogated) {
-    history.push({
-      name: APIProposalState.ABROGATED,
-      startTimestamp: nextDeadline,
-      endTimestamp: 0,
-      txHash: ""
-    });
-    return history;
-  }
-
-  // No abrogation proposal or did not pass
-  history.push({
-    name: APIProposalState.GRACE,
-    startTimestamp: nextDeadline,
-    endTimestamp: 0,
-    txHash: ""
-  });
-
-  nextDeadline += proposal.gracePeriodDuration;
-  if (eventsCopy.length > 0 && eventsCopy[0].createTime <= nextDeadline
-    && eventsCopy[0].eventType == APIProposalState.EXECUTED) {
-    history.push({
-      name: APIProposalState.EXECUTED,
-      startTimestamp: eventsCopy[0].createTime,
-      endTimestamp: 0,
-      txHash: eventsCopy[0].txHash
-    });
-    return history;
-  }
-
-  if (shouldStopBuilding(nextDeadline)) {
-    return history;
-  }
-
-  history.push({
-    name: APIProposalState.EXPIRED,
-    startTimestamp: nextDeadline,
-    endTimestamp: 0,
-    txHash: ""
-  });
-
-  return history;
-}
-
-async function buildProposalHistory(proposal: any): Promise<APIProposalHistoryEntity[]> {
-  let history = await calculateEvents(proposal);
-
-  // Sort and Populate Timestamps
-  history.sort((e1, e2) => {
-    if (e1.name == APIProposalState.CREATED && e2.name == APIProposalState.WARMUP) {
-      return 1;
-    } else if (e2.name == APIProposalState.CREATED && e1.name == APIProposalState.WARMUP) {
-      return -1;
-    }
-
-    if (e1.name == APIProposalState.ACCEPTED && e2.name == APIProposalState.QUEUED) {
-      return 1;
-    } else if (e2.name == APIProposalState.ACCEPTED && e1.name == APIProposalState.QUEUED) {
-      return -1;
-    }
-
-    return  e2.startTimestamp - e1.startTimestamp;
-  });
-
-  for (let i = 1; i <= history.length-1; i++) {
-    history[i].endTimestamp = history[i-1].startTimestamp -1;
-  }
-  history[0].endTimestamp = lastEventEndAt(proposal, history[0]);
-
-  return history;
-}
-
-function lastEventEndAt(proposal: any, event: APIProposalHistoryEntity): number {
-  switch (event.name) {
-    case APIProposalState.WARMUP:
-      return event.startTimestamp + proposal.warmUpDuration;
-    case APIProposalState.ACTIVE:
-      return event.startTimestamp + proposal.activeDuration;
-    case APIProposalState.QUEUED:
-      return event.startTimestamp + proposal.queueDuration;
-    case APIProposalState.GRACE:
-      return event.startTimestamp + proposal.gracePeriodDuration;
-    default:
-      return 0
-  }
-}
 
 export function fetchProposal(proposalId: number): Promise<APIProposalEntity> {
   const client = new ApolloClient({
@@ -567,7 +347,7 @@ export function fetchProposal(proposalId: number): Promise<APIProposalEntity> {
     })
     .then(async result => {
       console.log(result);
-      const history = await buildProposalHistory(result.data.proposal);
+      const history = await ProposalHistory.build(result.data.proposal);
       return {
         ...result.data.proposal,
         proposalId: result.data.proposal.id,

--- a/src/modules/governance/contracts/daoGovernance.ts
+++ b/src/modules/governance/contracts/daoGovernance.ts
@@ -87,7 +87,7 @@ export enum ProposalState {
   Executed,
 }
 
-function getProposalStateCall(proposalId: number): Promise<ProposalState> {
+export function getProposalStateCall(proposalId: number): Promise<ProposalState> {
   return Contract.call('state', [proposalId]).then(Number);
 }
 

--- a/src/modules/governance/contracts/daoGovernance.ts
+++ b/src/modules/governance/contracts/daoGovernance.ts
@@ -85,6 +85,7 @@ export enum ProposalState {
   Grace,
   Expired,
   Executed,
+  Abrogated
 }
 
 export function getProposalStateCall(proposalId: number): Promise<ProposalState> {
@@ -126,7 +127,7 @@ export type AbrogationProposal = {
   againstVotes: number;
 };
 
-function abrogationProposalCall(proposalId: number): Promise<AbrogationProposal> {
+export function abrogationProposalCall(proposalId: number): Promise<AbrogationProposal> {
   return Contract.call('abrogationProposals', [proposalId]);
 }
 

--- a/src/modules/governance/stateHistory.ts
+++ b/src/modules/governance/stateHistory.ts
@@ -1,0 +1,210 @@
+import {APIProposalHistoryEntity, APIProposalState} from "./api";
+import {getProposalStateCall, ProposalState} from "./contracts/daoGovernance";
+
+export namespace ProposalHistory {
+
+  /**
+   * Builds the Proposal History events based on the proposal
+   * @param proposal
+   */
+  export async function build(proposal: any): Promise<APIProposalHistoryEntity[]> {
+    let history = await calculateEvents(proposal);
+
+    // Sort and Populate Timestamps
+    history.sort((e1, e2) => {
+      if (e1.name == APIProposalState.CREATED && e2.name == APIProposalState.WARMUP) {
+        return 1;
+      } else if (e2.name == APIProposalState.CREATED && e1.name == APIProposalState.WARMUP) {
+        return -1;
+      }
+
+      if (e1.name == APIProposalState.ACCEPTED && e2.name == APIProposalState.QUEUED) {
+        return 1;
+      } else if (e2.name == APIProposalState.ACCEPTED && e1.name == APIProposalState.QUEUED) {
+        return -1;
+      }
+
+      return  e2.startTimestamp - e1.startTimestamp;
+    });
+
+    for (let i = 1; i <= history.length-1; i++) {
+      history[i].endTimestamp = history[i-1].startTimestamp -1;
+    }
+    history[0].endTimestamp = lastEventEndAt(proposal, history[0]);
+
+    return history;
+  }
+
+  /**
+   * Computes the time until a given state will end
+   * @param state
+   * @param proposal
+   */
+  export function computeTimeLeft(state: string, proposal: any): number {
+    const now = Math.floor(Date.now() / 1000);
+    switch (state) {
+      case APIProposalState.WARMUP:
+        return proposal.createTime + proposal.warmUpDuration - now;
+      case APIProposalState.ACTIVE:
+        return proposal.createTime + proposal.warmUpDuration + proposal.activeDuration - now;
+      case APIProposalState.QUEUED:
+        return proposal.createTime + proposal.warmUpDuration + proposal.activeDuration + proposal.queueDuration - now;
+      case APIProposalState.GRACE:
+        return proposal.createTime + proposal.warmUpDuration + proposal.queueDuration + proposal.gracePeriodDuration - now;
+      default:
+        return 0;
+    }
+  }
+}
+
+async function calculateEvents(proposal: any) {
+  let history = new Array<APIProposalHistoryEntity>();
+  let eventsCopy = JSON.parse(JSON.stringify(proposal.events)) as Array<any>;
+  eventsCopy.sort((a: any, b: any) => {
+    return a.createTime - b.createTime;
+  });
+
+  history.push({
+    name: APIProposalState.CREATED,
+    startTimestamp: proposal.createTime,
+    endTimestamp: 0,
+    txHash: eventsCopy[0].txHash
+  });
+  // Remove Created event
+  eventsCopy = eventsCopy.slice(1);
+  history.push({
+    name: APIProposalState.WARMUP,
+    startTimestamp: proposal.createTime,
+    endTimestamp: 0, //proposal.createTime+ proposal.warmUpDuration,
+    txHash: ""
+  });
+
+  let nextDeadline = proposal.createTime + proposal.warmUpDuration;
+  // at this point, only a CANCELED event can occur that would be final for this history
+  // so we check the list of events to see if there's any CANCELED event that occurred before the WARMUP period ended
+  checkForCancelledEvent(eventsCopy, nextDeadline, history);
+
+  if (shouldStopBuilding(nextDeadline)) {
+    return history;
+  }
+
+  // if the proposal was not canceled in the WARMUP period, then it means we reached ACTIVE state so we add that to
+  // the history
+  history.push({
+    name: APIProposalState.ACTIVE,
+    startTimestamp: nextDeadline + 1,
+    endTimestamp: 0,
+    txHash: ""
+  });
+
+  // just like in WARMUP period, the only final event that could occur in this case is CANCELED
+  nextDeadline = proposal.createTime + proposal.warmUpDuration + proposal.activeDuration;
+  checkForCancelledEvent(eventsCopy, nextDeadline, history);
+
+  if (shouldStopBuilding(nextDeadline)) {
+    return history;
+  }
+
+  const proposalState = await getProposalStateCall(proposal.id)
+  history.push({
+    name: proposalState === ProposalState.Failed ? APIProposalState.FAILED : APIProposalState.ACCEPTED,
+    startTimestamp: nextDeadline + 1,
+    endTimestamp: 0,
+    txHash: ""
+  });
+
+  // after the proposal reached accepted state, nothing else can happen unless somebody calls the queue function
+  // which emits a QUEUED event
+  if(eventsCopy.length == 0) {
+    return history;
+  }
+
+  if (eventsCopy[0].eventType == APIProposalState.QUEUED) {
+    history.push({
+      name: APIProposalState.QUEUED,
+      startTimestamp: proposal.createTime + proposal.warmUpDuration + proposal.activeDuration + 1,
+      endTimestamp: 0,
+      txHash: eventsCopy[0].txHash,
+    })
+  }
+  eventsCopy = eventsCopy.slice(1);
+
+  nextDeadline = proposal.createTime + proposal.warmUpDuration + proposal.activeDuration + proposal.queueDuration;
+  if (shouldStopBuilding(nextDeadline)) {
+    return history;
+  }
+
+  if (proposalState == ProposalState.Abrogated) {
+    history.push({
+      name: APIProposalState.ABROGATED,
+      startTimestamp: nextDeadline,
+      endTimestamp: 0,
+      txHash: ""
+    });
+    return history;
+  }
+
+  // No abrogation proposal or did not pass
+  history.push({
+    name: APIProposalState.GRACE,
+    startTimestamp: nextDeadline,
+    endTimestamp: 0,
+    txHash: ""
+  });
+
+  nextDeadline += proposal.gracePeriodDuration;
+  if (eventsCopy.length > 0 && eventsCopy[0].createTime <= nextDeadline
+    && eventsCopy[0].eventType == APIProposalState.EXECUTED) {
+    history.push({
+      name: APIProposalState.EXECUTED,
+      startTimestamp: eventsCopy[0].createTime,
+      endTimestamp: 0,
+      txHash: eventsCopy[0].txHash
+    });
+    return history;
+  }
+
+  if (shouldStopBuilding(nextDeadline)) {
+    return history;
+  }
+
+  history.push({
+    name: APIProposalState.EXPIRED,
+    startTimestamp: nextDeadline,
+    endTimestamp: 0,
+    txHash: ""
+  });
+
+  return history;
+}
+
+function lastEventEndAt(proposal: any, event: APIProposalHistoryEntity): number {
+  switch (event.name) {
+    case APIProposalState.WARMUP:
+      return event.startTimestamp + proposal.warmUpDuration;
+    case APIProposalState.ACTIVE:
+      return event.startTimestamp + proposal.activeDuration;
+    case APIProposalState.QUEUED:
+      return event.startTimestamp + proposal.queueDuration;
+    case APIProposalState.GRACE:
+      return event.startTimestamp + proposal.gracePeriodDuration;
+    default:
+      return 0
+  }
+}
+
+function shouldStopBuilding(nextDeadline: number) {
+  return nextDeadline >= Math.floor(Date.now() / 1000);
+}
+
+function checkForCancelledEvent(eventsCopy: Array<any>, nextDeadline: number, history: APIProposalHistoryEntity[]) {
+  if (eventsCopy.length > 0 && eventsCopy[0].createTime < nextDeadline && eventsCopy[0].eventType == "CANCELED") {
+    history.push({
+      name: APIProposalState.CANCELED,
+      startTimestamp: eventsCopy[0].createTime,
+      endTimestamp: 0,
+      txHash: eventsCopy[0].txHash
+    })
+  }
+}
+

--- a/src/modules/governance/views/proposal-detail-view/components/proposal-status-card/index.tsx
+++ b/src/modules/governance/views/proposal-detail-view/components/proposal-status-card/index.tsx
@@ -94,7 +94,7 @@ const ProposalStatusCard: React.FC = () => {
                 </Text>
 
                 {event.txHash && (
-                  <ExternalLink href={getEtherscanTxUrl(`0x${event.txHash}`)} style={{ height: '16px' }}>
+                  <ExternalLink href={getEtherscanTxUrl(event.txHash)} style={{ height: '16px' }}>
                     <Icon name="link-outlined" width={16} height={16} />
                   </ExternalLink>
                 )}

--- a/src/modules/governance/votingPower.ts
+++ b/src/modules/governance/votingPower.ts
@@ -1,0 +1,37 @@
+import BigNumber from "bignumber.js";
+import {APIVoterEntity} from "./api";
+
+const BASE_MULTIPLIER = new BigNumber(10).pow(18);
+const ONE_YEAR = new BigNumber(31556926); // 365 days, 5 hours, 48 minutes and 46 seconds
+
+export namespace VotingPower {
+
+  /**
+   * Calculates the voting power of the Voter based on the staked tokens, delegations and locking timestamp
+   * @param voter
+   */
+  export function calculate(voter: APIVoterEntity): BigNumber {
+    let now = Math.floor(Date.now() / 1000);
+    let ownVotingPower: BigNumber;
+    if (voter.hasActiveDelegation) {
+      ownVotingPower = BigNumber.ZERO;
+    } else {
+      const multiplier = computeMultiplier(voter.lockedUntil, now);
+      ownVotingPower = (new BigNumber(voter.tokensStaked)).multipliedBy(multiplier).dividedBy(BASE_MULTIPLIER);
+    }
+    return ownVotingPower.plus(voter.delegatedPower);
+  }
+
+}
+
+function computeMultiplier(lockedUntil: number, now: number) {
+  if (now >= lockedUntil) {
+    return BASE_MULTIPLIER;
+  }
+
+  let diff = new BigNumber(lockedUntil - now);
+  if (diff.gte(ONE_YEAR)) {
+    return BASE_MULTIPLIER.multipliedBy(new BigNumber(2));
+  }
+  return BASE_MULTIPLIER.plus(diff.multipliedBy(BASE_MULTIPLIER).dividedBy(ONE_YEAR));
+}

--- a/src/modules/yield-farming/api.ts
+++ b/src/modules/yield-farming/api.ts
@@ -2,8 +2,6 @@ import { ApolloClient, InMemoryCache, gql } from '@apollo/client';
 import BigNumber from 'bignumber.js';
 
 import config from 'config';
-import { result } from 'lodash';
-
 import { PaginatedResult } from 'utils/fetch';
 
 export enum APIYFPoolActionType {


### PR DESCRIPTION
- [X] Proposal loading issue resolved
- [X] Proposal history is being built
- [X] Voters for a given proposal are being fetched
- [X] Filter for Voters of a given proposal not working
- [X] Filter for Proposals
- [X] Proposal state is not being updated based on proposal history
- [x] Call at the contract after fetching the proposal to see whether the proposal has failed is hardcoded to `false`
- [x] Building event history does not account for abrogation proposals
- [x] Overview UI -> Voters have hardcoded voting power to the staked balance
- [ ] Use the graph for Abrogation Proposals instead of the API
- [ ] Voters for a given proposal not sorted by vote power
- [ ] Overview UI -> Voters are not sorted by Staked balance
